### PR TITLE
Allow DistributionalShapley example to finish on convergence

### DIFF
--- a/DistShap.py
+++ b/DistShap.py
@@ -294,7 +294,7 @@ class DistShap(object):
                 np.save(os.path.join(self.directory, 'loo.npy'), self.loo_vals)
             print('LOO values calculated!')
         iters = 0
-        while True:
+        while dist_run or tmc_run:
             if dist_run:
                 if error(self.results['mem_dist']) < err:
                     dist_run = False

--- a/DistShap.py
+++ b/DistShap.py
@@ -309,7 +309,7 @@ class DistShap(object):
                     self.vals_dist = np.mean(self.results['mem_tmc'], 0)
             if tmc_run:
                 if error(self.results['mem_tmc']) < err:
-                    dist_run = False
+                    tmc_run = False
                     print('Data Shapley has converged!')
                 else:
                     self._tmc_shap(

--- a/DistShap.py
+++ b/DistShap.py
@@ -306,7 +306,7 @@ class DistShap(object):
                         sources=self.sources,
                         alpha=alpha
                     )
-                    self.vals_dist = np.mean(self.results['mem_tmc'], 0)
+                    self.vals_dist = np.mean(self.results['mem_dist'], 0)
             if tmc_run:
                 if error(self.results['mem_tmc']) < err:
                     tmc_run = False


### PR DESCRIPTION
These changes help the Jupyter notebook example to finish by tracking TMC and Distributional Shapley progress separately as intended.